### PR TITLE
refactor: optimize Extract method and replace customData with optiona…

### DIFF
--- a/examples/extract_demo/main.go
+++ b/examples/extract_demo/main.go
@@ -36,15 +36,8 @@ func main() {
 	req.Header.Set("Authorization", "Bearer token123")
 	req.Header.Set("User-Agent", "MyApp/1.0")
 
-	// Custom data
-	customData := map[string]interface{}{
-		"user_id":    "12345",
-		"session_id": "abcdef",
-		"timestamp":  1694675400,
-	}
-
 	// Extract RequestData without parsing any template
-	requestData, err := p.Extract(req, customData)
+	requestData, err := p.Extract(req)
 	if err != nil {
 		log.Fatal("Failed to extract request data:", err)
 	}
@@ -88,7 +81,7 @@ func main() {
 	defer genericParser.Close()
 
 	// Extract using generic parser (same method, same result)
-	requestData2, err := genericParser.Extract(req, customData)
+	requestData2, err := genericParser.Extract(req)
 	if err != nil {
 		log.Fatal("Failed to extract request data with generic parser:", err)
 	}

--- a/examples/optimized_demo/main.go
+++ b/examples/optimized_demo/main.go
@@ -1,0 +1,73 @@
+package main
+
+import (
+	"fmt"
+	"log"
+	"net/http"
+
+	"github.com/fabricates/parser"
+)
+
+func main() {
+	fmt.Println("=== Optimized Extract with Provided Body Demo ===")
+
+	// Create parser with default settings
+	config := parser.Config{
+		MaxCacheSize: 10,
+		WatchFiles:   false,
+	}
+
+	p, err := parser.NewParser(config)
+	if err != nil {
+		log.Fatal("Failed to create parser:", err)
+	}
+	defer p.Close()
+
+	// Create a request with empty body initially
+	req, err := http.NewRequest("POST", "http://api.example.com/users", nil)
+	if err != nil {
+		log.Fatal("Failed to create request:", err)
+	}
+
+	req.Header.Set("Content-Type", "application/json")
+
+	// Provide external body data
+	externalBody := []byte(`{"name": "External Body", "provided": true, "optimized": "yes"}`)
+
+	// Extract using provided body (optimized - no ReadAll called on request body)
+	fmt.Println("1. Extract with provided body (optimized):")
+	requestData, err := p.Extract(req, externalBody)
+	if err != nil {
+		log.Fatal("Failed to extract with provided body:", err)
+	}
+
+	fmt.Printf("  Body from provided data: %s\n", requestData.Body)
+	fmt.Printf("  Parsed JSON name: %v\n", requestData.BodyJSON["name"])
+	fmt.Printf("  Parsed JSON optimized: %v\n", requestData.BodyJSON["optimized"])
+
+	// Extract without provided body (will read from request, which is empty)
+	fmt.Println("\n2. Extract without provided body:")
+	requestData2, err := p.Extract(req)
+	if err != nil {
+		log.Fatal("Failed to extract without provided body:", err)
+	}
+
+	fmt.Printf("  Body from request: '%s' (empty as expected)\n", requestData2.Body)
+	if requestData2.BodyJSON == nil {
+		fmt.Println("  BodyJSON: nil (no JSON to parse)")
+	}
+
+	fmt.Println("\n3. Comparison - body independence:")
+	fmt.Printf("  First extraction body length: %d\n", len(requestData.Body))
+	fmt.Printf("  Second extraction body length: %d\n", len(requestData2.Body))
+	fmt.Println("  ✓ Provided body doesn't affect original request body")
+
+	fmt.Println("\n=== Performance Benefits ===")
+	fmt.Println("✓ When body is provided:")
+	fmt.Println("  - No io.ReadAll() call on request body")
+	fmt.Println("  - No resetBody() calls needed")
+	fmt.Println("  - Direct use of provided data")
+	fmt.Println("✓ When body is not provided:")
+	fmt.Println("  - Normal ReadAll() and reset behavior")
+	fmt.Println("  - Backwards compatible with existing code")
+}

--- a/examples/slog_demo/main.go
+++ b/examples/slog_demo/main.go
@@ -26,7 +26,7 @@ func main() {
 	request.Header.Set("Content-Type", "application/json")
 
 	rereadableReq, _ := parser.NewRereadableRequest(request)
-	_, err := rereadableReq.Extract(nil)
+	_, err := rereadableReq.Extract()
 	if err != nil {
 		slog.Error("Request processing failed", "error", err)
 	}
@@ -41,7 +41,7 @@ func main() {
 	request2.Header.Set("Content-Type", "application/xml")
 
 	rereadableReq2, _ := parser.NewRereadableRequest(request2)
-	_, err2 := rereadableReq2.Extract(nil)
+	_, err2 := rereadableReq2.Extract()
 	if err2 != nil {
 		slog.Error("Request processing failed", "error", err2)
 	}

--- a/parser.go
+++ b/parser.go
@@ -15,7 +15,9 @@ type Parser interface {
 	ParseWith(templateName string, req *http.Request, customData interface{}, output io.Writer) (*RequestData, error)
 
 	// Extract extracts RequestData from the request without parsing any template
-	Extract(req *http.Request, customData interface{}) (*RequestData, error)
+	// If body is provided, it will be used instead of reading from the request's body stream
+	Extract(req *http.Request, body ...[]byte) (*RequestData, error)
+
 	// UpdateTemplate loads or updates a template with the given content
 	UpdateTemplate(name string, content string) error
 
@@ -36,7 +38,8 @@ type GenericParser[T any] interface {
 	ParseWith(templateName string, request *http.Request, data interface{}) (T, *RequestData, error)
 
 	// Extract extracts structured data from HTTP request without parsing templates
-	Extract(request *http.Request, customData interface{}) (*RequestData, error)
+	// If body is provided, it will be used instead of reading from the request's body stream
+	Extract(request *http.Request, body ...[]byte) (*RequestData, error)
 
 	// UpdateTemplate loads or updates a template with the given content
 	UpdateTemplate(name string, content string) error

--- a/parser_test.go
+++ b/parser_test.go
@@ -108,11 +108,14 @@ func TestExtractRequestData(t *testing.T) {
 	}
 
 	// Extract request data
-	customData := map[string]interface{}{"user": "test"}
-	data, err := rereadable.Extract(customData)
+	data, err := rereadable.Extract()
 	if err != nil {
 		t.Fatalf("Failed to extract request data: %v", err)
 	}
+
+	// Set custom data manually (since Extract no longer accepts it)
+	customData := map[string]interface{}{"user": "test"}
+	data.Custom = customData
 
 	// Test extracted data
 	if data.Body != body {
@@ -355,7 +358,7 @@ func BenchmarkRequestExtraction(b *testing.B) {
 			b.Fatalf("Failed to create re-readable request: %v", err)
 		}
 
-		_, err = rereadable.Extract(nil)
+		_, err = rereadable.Extract()
 		if err != nil {
 			b.Fatalf("Failed to extract request data: %v", err)
 		}
@@ -1452,7 +1455,7 @@ func TestExtractRequestDataMultipart(t *testing.T) {
 		t.Fatalf("Failed to create re-readable request: %v", err)
 	}
 
-	data, err := rereadable.Extract(nil)
+	data, err := rereadable.Extract()
 	if err != nil {
 		t.Fatalf("Failed to extract multipart request data: %v", err)
 	}
@@ -1478,7 +1481,7 @@ func TestExtractRequestDataJSON(t *testing.T) {
 		t.Fatalf("Failed to create re-readable request: %v", err)
 	}
 
-	data, err := rereadable.Extract(nil)
+	data, err := rereadable.Extract()
 	if err != nil {
 		t.Fatalf("Failed to extract JSON request data: %v", err)
 	}
@@ -1531,7 +1534,7 @@ func TestExtractRequestDataXML(t *testing.T) {
 		t.Fatalf("Failed to create re-readable request: %v", err)
 	}
 
-	data, err := rereadable.Extract(nil)
+	data, err := rereadable.Extract()
 	if err != nil {
 		t.Fatalf("Failed to extract XML request data: %v", err)
 	}
@@ -1571,7 +1574,7 @@ func TestExtractRequestDataSOAP(t *testing.T) {
 		t.Fatalf("Failed to create re-readable request: %v", err)
 	}
 
-	data, err := rereadable.Extract(nil)
+	data, err := rereadable.Extract()
 	if err != nil {
 		t.Fatalf("Failed to extract SOAP request data: %v", err)
 	}
@@ -1600,7 +1603,7 @@ func TestExtractRequestDataInvalidJSON(t *testing.T) {
 		t.Fatalf("Failed to create re-readable request: %v", err)
 	}
 
-	data, err := rereadable.Extract(nil)
+	data, err := rereadable.Extract()
 	if err != nil {
 		t.Fatalf("Failed to extract request data with invalid JSON: %v", err)
 	}
@@ -1647,7 +1650,7 @@ func TestExtractRequestDataContentTypeVariations(t *testing.T) {
 				t.Fatalf("Failed to create re-readable request: %v", err)
 			}
 
-			data, err := rereadable.Extract(nil)
+			data, err := rereadable.Extract()
 			if err != nil {
 				t.Fatalf("Failed to extract request data: %v", err)
 			}
@@ -1836,7 +1839,7 @@ func TestExtractRequestDataQueryEdgeCases(t *testing.T) {
 		t.Fatalf("Failed to create re-readable request: %v", err)
 	}
 
-	data, err := rereadable.Extract(nil)
+	data, err := rereadable.Extract()
 	if err != nil {
 		t.Fatalf("Failed to extract request data with invalid query: %v", err)
 	}
@@ -1849,7 +1852,7 @@ func TestExtractRequestDataQueryEdgeCases(t *testing.T) {
 	// Test with no query at all
 	req2, _ := http.NewRequest("GET", "http://example.com/test", nil)
 	rereadable2, _ := NewRereadableRequest(req2)
-	data2, err := rereadable2.Extract(nil)
+	data2, err := rereadable2.Extract()
 	if err != nil {
 		t.Fatalf("Failed to extract request data with no query: %v", err)
 	}
@@ -1990,7 +1993,7 @@ func TestFormParsingErrorHandling(t *testing.T) {
 	}
 
 	// This should still work even with malformed content type
-	data, err := rereadable.Extract(nil)
+	data, err := rereadable.Extract()
 	if err != nil {
 		t.Fatalf("Failed to extract request data: %v", err)
 	}


### PR DESCRIPTION
…l body parameter

This commit refactors the Extract method signature and optimizes body handling:

BREAKING CHANGES:
- Extract method now accepts optional []byte body instead of customData interface{}
- Parser.Extract(req, customData) -> Parser.Extract(req, body...)
- RereadableRequest.Extract() no longer accepts customData parameter
- Custom data in RequestData.Custom is now set to nil for basic Extract calls

NEW FEATURES:
- NewRereadableRequest constructor accepts optional body parameter
- When body is provided, it's used directly instead of calling ReadAll
- Optimized resetBody method skips operations for externally provided bodies
- Added new optimized_demo example showing performance benefits

OPTIMIZATIONS:
- No I/O overhead when body is provided externally
- Eliminates unnecessary ReadAll and Reset calls
- Direct memory usage of provided body data
- Maintains backwards compatibility for existing Parse/ParseWith methods

INTERFACE CHANGES:
- Parser.Extract(req *http.Request, body ...[]byte) (*RequestData, error)
- GenericParser[T].Extract(request *http.Request, body ...[]byte) (*RequestData, error)
- NewRereadableRequest(r *http.Request, body ...[]byte) (*RereadableRequest, error)

EXAMPLES:
- Updated extract_demo to use new signature
- Added optimized_demo showing performance benefits
- Fixed slog_demo to use correct method signatures

All tests pass and backwards compatibility is maintained for Parse/ParseWith methods. Custom data can still be used through ParseWith methods when needed.